### PR TITLE
Update github-actions.yml

### DIFF
--- a/example/github-actions.yml
+++ b/example/github-actions.yml
@@ -40,7 +40,7 @@ jobs:
       working-directory: core    
       run: |
         pip install pipenv
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@v0
       with:
        version: '290.0.0'
        service_account_key: 


### PR DESCRIPTION
fix below error.

```
Error: On 20[22](https://github.com/mfkessai/granter/runs/5637332328?check_suite_focus=true#step:6:22)-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.

We strongly advise updating your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'
```